### PR TITLE
Set Slack as main contact channel

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -39,7 +39,7 @@
           <ul class="dropdown-menu" role="menu">
             <li><a href="http://www.rocketryforum.com/forumdisplay.php?36-Rocketry-Electronics-and-Software">Help & Support (Rocketry Forum)</a></li>
             <li><a href="contribute.html">Get Involved!</a></li>
-            <li><a href="contact.html">The Dev Team</a></li>
+            <li><a href="contact.html">Contact Info</a></li>
           </uL>
         </li>
       </ul>

--- a/contact.md
+++ b/contact.md
@@ -4,6 +4,12 @@ id: contact
 title: OpenRocket — Support and contact information
 ---
 
+## Slack Workspace
+
+The most active communication channel is our Slack workspace, which you can join by clicking the link below.
+
+[https://join.slack.com/t/openrocket/shared_invite/zt-dh0wtpc4-WmkSK1ysqAOqHa6eFN7zgA](https://join.slack.com/t/openrocket/shared_invite/zt-dh0wtpc4-WmkSK1ysqAOqHa6eFN7zgA)
+
 ## Mailing Lists
 
 OpenRocket currently has two emailing lists for interested users:
@@ -23,9 +29,3 @@ well. List members can not unsubscribe for you; _Please do not send unsubscripti
 The official support forum for OpenRocket is the [Rocketry Electronics and Software forum](http://www.rocketryforum.com/forumdisplay.php?36-Rocketry-Electronics-and-Software) at [The Rocketry Forum](http://www.rocketryforum.com/).
 
 Please ask any questions on using OpenRocket on that forum, where others can answer as well and gain knowledge from the answers.
-
-## Slack Workspace (Experimental)
-
-The development team is experimenting with a Slack workspace, which can be joined by clicking the link below.
-
-[https://join.slack.com/t/openrocket/shared_invite/zt-dh0wtpc4-WmkSK1ysqAOqHa6eFN7zgA](https://join.slack.com/t/openrocket/shared_invite/zt-dh0wtpc4-WmkSK1ysqAOqHa6eFN7zgA)


### PR DESCRIPTION
Previously, on the Contact-page, Slack was still mentioned as being experimental. I think it's fair to say that Slack is the most active communication channel in the dev team. So I removed the experimental-text and put Slack as the first item on the contact page.