### PR TITLE
[fixes #25] Use https links instead of http

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ description: > # this means to ignore newlines until "baseurl:"
   OpenRocket is a free, fully featured model rocket simulator that allows you to
   design and simulate your rockets before actually building and flying them.
 baseurl: "" # the subpath of your site, e.g. /blog/
-url: "http://openrocket.info" # the base hostname & protocol for your site
+url: "https://openrocket.info" # the base hostname & protocol for your site
 #twitter_username: jekyllrb
 github_username:  openrocket 
 current_version: 15.03

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,7 +3,7 @@
     <hr>
     <footer>
     <p class="text-center">
-<a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0; padding-right: 10px" title="CC BY-SA" src="http://mirrors.creativecommons.org/presskit/buttons/80x15/svg/by-sa.svg" /></a><span xmlns:dct="http://purl.org/dc/terms/" property="dct:title">The OpenRocket WebSite</span> by <a xmlns:cc="http://creativecommons.org/ns#" href="http://openrocket.info" property="cc:attributionName" rel="cc:attributionURL">OpenRocket</a> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.
+<a rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0; padding-right: 10px" title="CC BY-SA" src="https://mirrors.creativecommons.org/presskit/buttons/80x15/svg/by-sa.svg" /></a><span xmlns:dct="https://purl.org/dc/terms/" property="dct:title">The OpenRocket WebSite</span> by <a xmlns:cc="https://creativecommons.org/ns#" href="https://openrocket.info" property="cc:attributionName" rel="cc:attributionURL">OpenRocket</a> is licensed under a <a rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.
     </p>
     <p class="text-center">Content may be individually licensed with lesser or greater restrictions and will be marked accordingly.</p>
     </footer>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -25,8 +25,8 @@
           <ul class="dropdown-menu" role="menu">
 
             <li><a href="/features.html">Screenshots &amp; Features</a></li>
-            <li><a href="http://wiki.openrocket.info/User%27s_Guide">User Guides (Wiki)</a></li>
-            <li><a href="http://wiki.openrocket.info/Main_Page">More Guides (Wiki)</a></li>
+            <li><a href="https://wiki.openrocket.info/User%27s_Guide">User Guides (Wiki)</a></li>
+            <li><a href="https://wiki.openrocket.info/Main_Page">More Guides (Wiki)</a></li>
             <li><a href="/documentation.html">Technical Docs</a></li>
             <li><a href="release_notes.html">Release Notes</a></li>
           </ul>
@@ -37,7 +37,7 @@
         <li class="dropdown">
           <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Contact<span class="caret"></span></a>
           <ul class="dropdown-menu" role="menu">
-            <li><a href="http://www.rocketryforum.com/forumdisplay.php?36-Rocketry-Electronics-and-Software">Help & Support (Rocketry Forum)</a></li>
+            <li><a href="https://www.rocketryforum.com/forumdisplay.php?36-Rocketry-Electronics-and-Software">Help & Support (Rocketry Forum)</a></li>
             <li><a href="contribute.html">Get Involved!</a></li>
             <li><a href="contact.html">Contact Info</a></li>
           </uL>

--- a/contact.md
+++ b/contact.md
@@ -19,13 +19,13 @@ OpenRocket currently has two emailing lists for interested users:
  - [OpenRocket-devel](https://lists.sourceforge.net/lists/listinfo/openrocket-devel) ([archives](https://sourceforge.net/mailarchive/forum.php?forum_name=openrocket-devel))
    Discussion related to OpenRocket development, documentation and upcoming features.
 
-You are welcome to join the development mailing list if you are interested in contributing something to OpenRocket or simply want hear about and discuss future development. Note that support requests should be sent to the [support forums](http://www.rocketryforum.com/forumdisplay.php?f=36) instead!
+You are welcome to join the development mailing list if you are interested in contributing something to OpenRocket or simply want hear about and discuss future development. Note that support requests should be sent to the [support forums](https://www.rocketryforum.com/forumdisplay.php?f=36) instead!
 
 Unsubscribing from the lists can be performed in the above links as
 well. List members can not unsubscribe for you; _Please do not send unsubscription requests to the list._
 
 ## Support Forums
 
-The official support forum for OpenRocket is the [Rocketry Electronics and Software forum](http://www.rocketryforum.com/forumdisplay.php?36-Rocketry-Electronics-and-Software) at [The Rocketry Forum](http://www.rocketryforum.com/).
+The official support forum for OpenRocket is the [Rocketry Electronics and Software forum](https://www.rocketryforum.com/forumdisplay.php?36-Rocketry-Electronics-and-Software) at [The Rocketry Forum](https://www.rocketryforum.com/).
 
 Please ask any questions on using OpenRocket on that forum, where others can answer as well and gain knowledge from the answers.

--- a/contribute.md
+++ b/contribute.md
@@ -40,7 +40,7 @@ There is still work to be done in the aerodynamic computation methods of OpenRoc
 
 ## Documentation tasks
 
-Contributions to the [OpenRocket User's guide](http://wiki.openrocket.info/User%27s_Guide) are dearly needed. Below are examples of topics.
+Contributions to the [OpenRocket User's guide](https://wiki.openrocket.info/User%27s_Guide) are dearly needed. Below are examples of topics.
 
  - Getting started guide
  - How to make staged and clustered designs

--- a/documentation.md
+++ b/documentation.md
@@ -15,7 +15,7 @@ Master's thesis.
  - [OpenRocket technical documentation](https://github.com/openrocket/openrocket/releases/download/OpenRocket_technical_documentation-v13.05/OpenRocket_technical_documentation-v13.05.pdf) (2013-05-10)    (PDF 1.4MB)
  - [Development of an Open Source model rocket simulation software (Master's thesis)](https://github.com/openrocket/openrocket/releases/download/Development_of_an_Open_Source_model_rocket_simulation-thesis-v20090520/Development_of_an_Open_Source_model_rocket_simulation-thesis-v20090520.pdf)  (2013-05-20)  (PDF 1.3MB)
 
-The technical documentation is licensed under a [Creative Commons Attribution-ShareAlike License](http://creativecommons.org/licenses/by-sa/3.0/) while the Master's thesis is licensed under a [Attribution-NonCommercial-NoDerivs License](http://creativecommons.org/licenses/by-nd-nc/1.0/fi/deed.en).
+The technical documentation is licensed under a [Creative Commons Attribution-ShareAlike License](http://creativecommons.org/licenses/by-sa/3.0/) while the Master's thesis is licensed under a [Attribution-NonCommercial-NoDerivs License](https://creativecommons.org/licenses/by-nd-nc/1.0/fi/deed.en).
 
 ## Install4j
 
@@ -25,4 +25,4 @@ Thanks to a generous license for open source projects, OpenRocket uses [Install4
 
 ## Resources
 
-A list of useful technical rocketry resources is available in the ["Resources" wiki page](http://wiki.openrocket.info/Resources), including links to Barrowman's original report and thesis, extensions for the Barrowman method, experimental rocket data etc.
+A list of useful technical rocketry resources is available in the ["Resources" wiki page](https://wiki.openrocket.info/Resources), including links to Barrowman's original report and thesis, extensions for the Barrowman method, experimental rocket data etc.

--- a/features.md
+++ b/features.md
@@ -18,7 +18,7 @@ id: features
 
  - **Fully cross-platform**, written in Java
  - **Fully documented** [simulation methods](/documentation.html)
- - **Open Source**, source code available under the [GNU GPL](http://www.gnu.org/licenses/gpl-3.0.txt)
+ - **Open Source**, source code available under the [GNU GPL](https://www.gnu.org/licenses/gpl-3.0.txt)
 
 ### User interface
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "bugs": {
     "url": "https://github.com/openrocket/openrocket.github.io/issues"
   },
-  "homepage": "http://openrocket.info",
+  "homepage": "https://openrocket.info",
   "devDependencies": {
     "connect-livereload": "^0.5.3",
     "grunt": "^0.4.5",


### PR DESCRIPTION
This PR changes a bunch of https links on the website to http links. Some links could not be converted to http (like http://openrocket.trans.free.fr/).