### PR TITLE
Move install4j to Download-page

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -17,16 +17,6 @@ Master's thesis.
 
 The technical documentation is licensed under a [Creative Commons Attribution-ShareAlike License](http://creativecommons.org/licenses/by-sa/3.0/) while the Master's thesis is licensed under a [Attribution-NonCommercial-NoDerivs License](https://creativecommons.org/licenses/by-nd-nc/1.0/fi/deed.en).
 
-## install4j
-
-Thanks to a generous license for open source projects, OpenRocket uses
-the [install4j multi-platform installer builder](https://www.ej-technologies.com/products/install4j/overview.html) to produce installers for Windows, macOS and Linux. 
-
-<a href="https://www.ej-technologies.com/products/install4j/overview.html" role="button">
-    <img alt="Download install4j" src="img/install4j_download_btn.png">
-</a>
-
-
 ## Resources
 
 A list of useful technical rocketry resources is available in the ["Resources" wiki page](https://wiki.openrocket.info/Resources), including links to Barrowman's original report and thesis, extensions for the Barrowman method, experimental rocket data etc.

--- a/downloads.md
+++ b/downloads.md
@@ -55,3 +55,14 @@ Finally, you can simply go to the source repository on GitHub
 <a class="btn btn-success btn-lg" href="https://github.com/openrocket/openrocket" role="button">Fork me on GitHub</a>
   </div>
 </div>
+
+<hr/>
+
+## install4j
+
+Thanks to a generous license for open source projects, OpenRocket uses
+the [install4j multi-platform installer builder](https://www.ej-technologies.com/products/install4j/overview.html) to produce installers for Windows, macOS and Linux. 
+
+<a href="https://www.ej-technologies.com/products/install4j/overview.html" role="button">
+    <img alt="Download install4j" src="img/install4j_download_btn.png">
+</a>


### PR DESCRIPTION
I never really understood why the install4j-information was located in the technical docs section. This PR moves it to the bottom of the download-page (since that's where the packaged installers are located).

<img width="1675" alt="image" src="https://user-images.githubusercontent.com/11031519/155407973-ac3b4e51-341f-4973-bbe4-d3bd10956850.png">
