### PR TITLE
Use English site of translate tutorial

### DIFF
--- a/contribute.md
+++ b/contribute.md
@@ -58,7 +58,7 @@ Testers are both a developer's best friend and worst nightmare. They test new fe
 
 ## Other
 
- - [Translating OpenRocket](http://openrocket.trans.free.fr/){:target="_blank"} to your language
+ - [Translating OpenRocket](http://openrocket.trans.free.fr/index.php?lang=en){:target="_blank"} to your language
  - Creating good and interesting example designs that demonstrate some OpenRocket features.
  - Hosting a place to share rocket designs with other enthusiasts.
  - Giving input and suggestions on how to make OpenRocket better.


### PR DESCRIPTION
The hyperlink to the info for translating OR is by default in French. This PR changes it to English.