### PR TITLE
Redirect downloads button to downloads page

### DIFF
--- a/_includes/download_button.html
+++ b/_includes/download_button.html
@@ -1,4 +1,4 @@
-<a class="btn btn-primary btn-lg btn-download" href="downloads.html" role="button"é>
+<a class="btn btn-primary btn-lg btn-download" href="downloads.html" role="button">
     <i class="fa-solid fa-download" style="margin-right: 1.5rem"></i>
     <span>Download v{{site.current_version}}</span>
 </a>

--- a/_includes/jumbotron.html
+++ b/_includes/jumbotron.html
@@ -13,10 +13,10 @@
       <div class="dropdown" style="margin-left: 20px;">
         <button class="dropbtn dropbtn-dark">Other operating systems<i class="fa-solid fa-angle-down" style="margin-left: 15px;"></i></button>
         <div class="dropdown-content">
-          <a href="https://github.com/openrocket/openrocket/releases/download/release-{{site.current_version}}/OpenRocket-{{site.current_version}}-Windows.exe">Windows</a>
-          <a href="https://github.com/openrocket/openrocket/releases/download/release-{{site.current_version}}/OpenRocket-{{site.current_version}}-macOS.dmg">macOS</a>
-          <a href="https://github.com/openrocket/openrocket/releases/download/release-{{site.current_version}}/OpenRocket-{{site.current_version}}-Linux.sh">Linux</a>
-          <a href="https://github.com/openrocket/openrocket/releases/download/release-{{site.current_version}}/OpenRocket-{{site.current_version}}.jar">JAR</a>
+          <a href="downloads.html?vers={{site.current_version}}#content-Windows">Windows</a>
+          <a href="downloads.html?vers={{site.current_version}}#content-macOS">macOS</a>
+          <a href="downloads.html?vers={{site.current_version}}#content-Linux">Linux</a>
+          <a href="downloads.html?vers={{site.current_version}}#content-JAR">JAR</a>
         </div>
       </div>
     </div>

--- a/css/main.css
+++ b/css/main.css
@@ -124,6 +124,14 @@ nav.navbar {
   color: white;
 }
 
+.downloads-os-title {
+  padding-top: 50px;
+}
+
+.separator-downloads {
+  margin-top: 40px;
+}
+
 .donate-button {
   margin-top: 13px;
   margin-left: 2em;

--- a/downloads.md
+++ b/downloads.md
@@ -26,20 +26,20 @@ the needed dependencies, including the correct version of Java.
   <strong>What's new?</strong> Check out the <a href="release_notes.html">release notes</a>.
 </div>
 
-<hr/>
+<hr class="separator-downloads"/>
 
 <div id="downloads-content">
   <div id="content-Windows">
-    <h3><i class="fa-brands fa-windows"></i> Windows</h3>
+    <h3 class="downloads-os-title"><i class="fa-brands fa-windows"></i> Windows</h3>
     <a class="btn btn-primary btn-lg" role="button"></a>
     <button type="button" class="collapsible" style="margin-top: 15px">Show Windows installation instructions</button>
     <div id="instructions-Windows" class="collapsible-content"></div>
   </div>
 
-  <hr/>
+  <hr class="separator-downloads"/>
 
   <div id="content-macOS">
-    <h3><i class="fa-brands fa-apple"></i> macOS</h3>
+    <h3 class="downloads-os-title"><i class="fa-brands fa-apple"></i> macOS</h3>
     <div id="fillContent-macOS">
     </div>
     <a class="btn btn-primary btn-lg" role="button"></a>
@@ -47,19 +47,19 @@ the needed dependencies, including the correct version of Java.
     <div id="instructions-macOS" class="collapsible-content"></div>
   </div>
 
-  <hr/>
+  <hr class="separator-downloads"/>
 
   <div id="content-Linux">
-    <h3><i class="fa-brands fa-linux"></i> Linux</h3>
+    <h3 class="downloads-os-title"><i class="fa-brands fa-linux"></i> Linux</h3>
     <a class="btn btn-primary btn-lg" role="button"></a>
     <button type="button" class="collapsible" style="margin-top: 15px">Show Linux installation instructions</button>
     <div id="instructions-Linux" class="collapsible-content"></div>
   </div>
 
-  <hr/>
+  <hr class="separator-downloads"/>
 
   <div id="content-JAR">
-    <h3><i class="fa-brands fa-java"></i> JAR</h3>
+    <h3 class="downloads-os-title"><i class="fa-brands fa-java"></i> JAR</h3>
     Again, we <b>strongly</b> recommend you use one of the packages described above.<br/>
     <a class="btn btn-primary btn-lg" role="button"></a>
     <button type="button" class="collapsible" style="margin-top: 15px">Show JAR installation instructions</button>
@@ -74,7 +74,7 @@ the needed dependencies, including the correct version of Java.
 
   <div id="content-source">
     <h2>Source code</h2>
-    The source code can be downloaded as either a .zip file or a .tar.gz file  
+    The source code can be downloaded as either a .zip file or a .tar.gz file. 
     <div>
       <a id="source-zip" class="btn btn-primary btn-lg" role="button"></a>  
       <a id="source-tar.gz" class="btn btn-primary btn-lg" role="button"></a>
@@ -83,9 +83,8 @@ the needed dependencies, including the correct version of Java.
 </div>
 
 <br>
-<h3> Obtain from the Repository on GitHub <i class="fa-brands fa-github"></i></h3>
-Finally, you can simply go to the source repository on GitHub. 
-<a class="btn btn-success btn-lg" href="https://github.com/openrocket/openrocket" role="button">Fork me on GitHub</a>
+Or you can simply go to our source repository on GitHub. 
+<div><a class="btn btn-success btn-lg" href="https://github.com/openrocket/openrocket" target="_blank" role="button"><i class="fa-brands fa-github" style="margin-right: 1.5rem"></i>Fork me on GitHub</a></div>
 
 <br>
 <hr/>

--- a/js/download_button.js
+++ b/js/download_button.js
@@ -12,19 +12,19 @@ function setDownloadTextByOS(btn) {
     if (os.indexOf("Win") != -1) {
         icon.className = "fa-brands fa-windows";
         btnText.innerHTML = btnInitText + " for Windows";
-        btn.href = `https://github.com/openrocket/openrocket/releases/download/release-${version}/OpenRocket-${version}-Windows.exe`;
+        btn.href = `downloads.html?vers=${version}#content-Windows`;
     } else if (os.indexOf("Mac") != -1) {
         icon.className = "fa-brands fa-apple";
         btnText.innerHTML = btnInitText + " for macOS";
-        btn.href = `https://github.com/openrocket/openrocket/releases/download/release-${version}/OpenRocket-${version}-macOS.dmg`;
+        btn.href = `downloads.html?vers=${version}#content-macOS`;
     } else if (os.indexOf("Linux") != -1) {
         icon.className = "fa-brands fa-linux";
         btnText.innerHTML = btnInitText + " for Linux";
-        btn.href = `https://github.com/openrocket/openrocket/releases/download/release-${version}/OpenRocket-${version}-Linux.sh`;
+        btn.href = `downloads.html?vers=${version}#content-Linux`;
     } else {
-        icon.className = "fa-brands fa-java";
-        btnText.innerHTML = btnInitText + " as a JAR";
-        btn.href = `https://github.com/openrocket/openrocket/releases/download/release-${version}/OpenRocket-${version}.jar`;
+        icon.className = "fa-solid fa-download";
+        btnText.innerHTML = btnInitText;
+        btn.href = `downloads.html?vers=${version}`;
     }
 }
 

--- a/js/fill_downloads.js
+++ b/js/fill_downloads.js
@@ -85,7 +85,7 @@ function fillOSContent(version, configObj, OSName, ...architectures) {
             archBtn.style.left = "10em";
             archBtn.role = "button";
             archBtn.href = `https://github.com/openrocket/openrocket/releases/download/release-${version}/${archFile}`;
-            archBtn.innerHTML = `Download ${archFile}`;
+            archBtn.innerHTML = `<i class="fa-solid fa-download" style="margin-right: 1.5rem"></i>Download ${archFile}`;
             fillContent.append(archBtn);
             fillContent.append(document.createElement('br'));
         }
@@ -93,7 +93,7 @@ function fillOSContent(version, configObj, OSName, ...architectures) {
         // Update the download button content
         const OSFile = configObj[`${OSName}File`];
         btn.href = `https://github.com/openrocket/openrocket/releases/download/release-${version}/${OSFile}`;
-        btn.innerHTML = `Download ${OSFile}`;
+        btn.innerHTML = `<i class="fa-solid fa-download" style="margin-right: 1.5rem"></i>Download ${OSFile}`;
     }
 
     // Add the instructions
@@ -120,7 +120,7 @@ function fillOSContent(version, configObj, OSName, ...architectures) {
 function fillSourceCode(version, format) {
     let elem = document.getElementById(`source-${format}`)
     elem.href = `https://github.com/openrocket/openrocket/archive/refs/tags/release-${version}.${format}`;
-    elem.innerHTML = `Download release-${version}.${format}`;
+    elem.innerHTML = `<i class="fa-solid fa-download" style="margin-right: 1.5rem"></i>Download release-${version}.${format}`;
 }
 
 window.onload = function() {


### PR DESCRIPTION
This PR changes the behavior of the download-button on the home page. Instead of downloading OR directly, it will now redirect you to the downloads page, with a hyperlink to the download section of your OS. With this new behavior, my concern in the comment of PR #81 is now fixed as well.

I also added a download icon to the download buttons to let them stand out more. I also vertically separated the different download sections for more contrast:

https://user-images.githubusercontent.com/11031519/216807849-2a80649e-c1e1-4ca6-8004-a8f43f19e7aa.mp4

