### PR TITLE
Replace Slack info with Discord info

### DIFF
--- a/_includes/contribute-home.md
+++ b/_includes/contribute-home.md
@@ -1,5 +1,5 @@
 <h2>
-    <a href="https://github.com/openrocket/openrocket" class="a-no-format">
+    <a href="https://github.com/openrocket/openrocket" target="_blank" class="a-no-format">
         <i class="fa fa-github"></i> Open source
     </a>
 </h2>

--- a/contact.md
+++ b/contact.md
@@ -4,11 +4,11 @@ id: contact
 title: OpenRocket — Support and contact information
 ---
 
-<h2 id="slack">Slack Workspace</h2>
+<h2 id="discord">Discord Server</h2>
 
-The most active communication channel is our Slack workspace, which you can join by clicking the link below.
+The most active communication channel is our Discord server, which you can join by clicking the link below.
 
-[https://join.slack.com/t/openrocket/shared_invite/zt-dh0wtpc4-WmkSK1ysqAOqHa6eFN7zgA](https://join.slack.com/t/openrocket/shared_invite/zt-dh0wtpc4-WmkSK1ysqAOqHa6eFN7zgA)
+[https://discord.gg/qD2G5v2FAw](https://discord.gg/qD2G5v2FAw)
 
 ## Mailing Lists
 

--- a/contribute.md
+++ b/contribute.md
@@ -8,7 +8,7 @@ id: contribute
 
 OpenRocket is an Open Source project, meaning that the source code is freely available and anybody can help make the software better. You don't even need coding skills, as there are other things to do as well.
 
-Below are a few suggestions of areas that would need help. If you'd like to participate, you can send us a message [on Slack](contact.html#slack){:target="_blank"}, file an issue for your suggestion [on GitHub](https://github.com/openrocket/openrocket/issues){:target="_blank"} or [join the development mailing list](https://lists.sourceforge.net/lists/listinfo/openrocket-devel){:target="_blank"} and introduce your ideas there.
+Below are a few suggestions of areas that would need help. If you'd like to participate, you can send us a message [on Discord](contact.html#discord){:target="_blank"}, file an issue for your suggestion [on GitHub](https://github.com/openrocket/openrocket/issues){:target="_blank"} or [join the development mailing list](https://lists.sourceforge.net/lists/listinfo/openrocket-devel){:target="_blank"} and introduce your ideas there.
 
  - Java development
  - Aerodynamic computation methods

--- a/css/main.css
+++ b/css/main.css
@@ -82,6 +82,10 @@ body#landing-page a.navbar-brand.navbar-visible-on-scroll, body#landing-page #na
   transition: opacity 2s ease 0s;
 }
 
+div.join-discord {
+  padding-top: 2px;
+}
+
 div.contribute-home {
   padding-top: 2px;
   padding-bottom: 40px;

--- a/index.html
+++ b/index.html
@@ -97,7 +97,27 @@ id: landing-page
 
 <hr style="margin-top: 53px;"/>
 
-<div class="contribute-home">
+<div class="row join-discord">
+  <h2>
+    <a href="https://discord.gg/qD2G5v2FAw" class="a-no-format" target="_blank">
+        <i class="fab fa-discord"></i> Join our Discord community
+    </a>
+  </h2>
+
+  <div>
+    <p>Connect with fellow rocket enthusiasts, ask questions about rocket designs, share your experiences, and get in touch with our developers.</p>
+    <p>Our Discord server is the perfect place to <b>discuss, learn</b>, and <b>have fun with like-minded individuals</b>. Click the button below to join:</p>
+    <p>
+      <a href="https://discord.gg/qD2G5v2FAw" target="_blank" class="btn btn-lg btn-primary">
+        <i class="fab fa-discord" style="margin-right: 1rem"></i> Join our Discord Server
+      </a>
+    </p>
+  </div>
+</div>
+
+<hr style="margin-top: 23px;"/>
+
+<div class="row contribute-home">
   {% capture my_include %}{% include contribute-home.md %}{% endcapture %}
   {{ my_include | markdownify }}
 </div>


### PR DESCRIPTION
This PR replaces the Slack info with our new Discord server info.
<img width="1177" alt="image" src="https://user-images.githubusercontent.com/11031519/231844009-ebbcc91f-d4a7-4298-84b7-4d045f844c96.png">

Also added a section to our home page:
<img width="1247" alt="image" src="https://user-images.githubusercontent.com/11031519/231844085-3719705a-dc4c-493f-a56c-3ff087d3123b.png">
