### PR TITLE
Update JAR instructions for Java 17

### DIFF
--- a/downloads/instructions/JAR_new.md
+++ b/downloads/instructions/JAR_new.md
@@ -5,10 +5,7 @@
     }
 </style>
 
-To use the .jar file, download it, and start it from the
-command line with: `java -jar OpenRocket-${VERSION}$.jar`
-
-You **must** use Java 11 or Java 17 for this to work. Java 17 is recommended.
+You **must** use Java 17. To run the .jar file, download it, and start it from the command line with: `java -jar OpenRocket-${VERSION}$.jar`
 
 <b style="color: red">Important note</b>: Java 17 can cause issues for some people, most noticeably the 3D view can be 
 broken for Windows users. A workaround for this is to run the JAR file using the command:


### PR DESCRIPTION
The website states you can run the JAR with Java 11. This is not the case anymore - you will get an exception.